### PR TITLE
bug fix

### DIFF
--- a/Assets/Script/BossMonster/BossMonsterNetworked.cs
+++ b/Assets/Script/BossMonster/BossMonsterNetworked.cs
@@ -283,8 +283,9 @@ public class BossMonsterNetworked : NetworkBehaviour
             {
                 // Initialize the Ball before synchronizing it
                 var script = o.GetComponent<BossSwordEnergy>();
-                script.Init();
+                script.Init((int)BossScale);
                 script.damage = 100;
+                
             }
         );
         var attackLengthTimer = CustomTickTimer.CreateFromSeconds(Runner, attackLength);

--- a/Assets/Script/BossMonster/BossSwordEnergy.cs
+++ b/Assets/Script/BossMonster/BossSwordEnergy.cs
@@ -9,10 +9,15 @@ public class BossSwordEnergy : NetworkBehaviour
     public int damage = 10;
     public float speed = 5;
     public float lifeSeconds = 3;
+    private int dir = 1;
     public AudioClip attackClip;
-    public void Init()
+    public void Init(int _dir)
     {
         life = TickTimer.CreateFromSeconds(Runner, lifeSeconds);
+
+        dir = _dir / Mathf.Abs(_dir);
+
+        transform.localScale = new Vector3(dir, 1);
     }
 
     public override void FixedUpdateNetwork()
@@ -20,7 +25,7 @@ public class BossSwordEnergy : NetworkBehaviour
         if (life.Expired(Runner))
             Runner.Despawn(Object);
         else
-            transform.position += speed * transform.right * Runner.DeltaTime;
+            transform.position += speed * transform.right * Runner.DeltaTime * dir;
     }
 
     void OnTriggerEnter2D(Collider2D other)


### PR DESCRIPTION
## 문제점
- 검기가 한 방향으로밖에 나가지 않음
## 해결
- 보스의 x스케일로 방향을 지정하는것에서 착안해 보스의 x스케일을 검기의 방향에 사용하고자 함 
- Init()에서 보스의 스케일을 받아올수 있게 매개변수 _dir을 추가함
- dir에 _dir을 노말라이징 하여 저장함
- dir을 검기의 x 스케일로 지정함
- dir을 FixedUpdateNetwork의 검기 위치 업데이트 코드에 곱함
## 결과
**정상작동함**